### PR TITLE
multiple AS topology parsed from multiple rocketfuel

### DIFF
--- a/icarus/scenarios/topology.py
+++ b/icarus/scenarios/topology.py
@@ -835,7 +835,7 @@ def topology_multi_as(asns, source_ratio=0.1, ext_delay=EXTERNAL_LINK_DELAY, **k
         while k < len(routerslist):
             i = 0
             while i < numEBGP:
-                topologylist[j].add_edge(routerslist[j][i], routerslist[k][i], delay=25, type='external')
+                topologylist[j].add_edge(routerslist[j][i], routerslist[k][i], delay = ext_delay, type='external')
                 i += 1
             k += 1
 
@@ -906,15 +906,9 @@ def topology_multi_as(asns, source_ratio=0.1, ext_delay=EXTERNAL_LINK_DELAY, **k
     for v in routerall:
         fnss.add_stack(topo_multiAS, v, 'router')
     for u, v in topo_multiAS.edges():
-        if topo_multiAS.edge[u][v]['type'] == 'external':
-            print (u,v,topo_multiAS.edge[u][v])
         if u in sources or v in sources:
-            topo_multiAS.edge[u][v]['type'] = 'external'
             # this prevents sources to be used to route traffic
             fnss.set_weights_constant(topo_multiAS, 1000.0, [(u, v)])
-            fnss.set_delays_constant(topo_multiAS, EXTERNAL_LINK_DELAY, 'ms', [(u, v)])
-        else:
-            topo_multiAS.edge[u][v]['type'] = 'internal'
     return IcnTopology(topo_multiAS)
 
 def mapping(x):

--- a/icarus/scenarios/topology.py
+++ b/icarus/scenarios/topology.py
@@ -796,7 +796,7 @@ def topology_multi_as(asns, source_ratio=0.1, ext_delay=EXTERNAL_LINK_DELAY, **k
     # First mark all current links as inernal
     for topology in topologylist:
         j = topologylist.index(topology)
-        while j>=0:
+        while j>=1:
             topology=nx.relabel_nodes(topology,mapping, copy=False)
             j -= 1
     for topology in topologylist:

--- a/icarus/scenarios/topology.py
+++ b/icarus/scenarios/topology.py
@@ -770,15 +770,14 @@ def topology_rocketfuel_latency(asn, source_ratio=0.1, ext_delay=EXTERNAL_LINK_D
     return IcnTopology(topology)
 
 
-
 @register_topology_factory('MULTIAS')
 def topology_multi_as(asns, source_ratio=0.1, ext_delay=EXTERNAL_LINK_DELAY, **kwargs):
     """Parse multiple generic RocketFuel topologies as a multiple AS topology 
     with annotated latencies. Each topology works as an individual AS. 
     To each node of the parsed topology it is attached an artificial receiver
     node. To the routers with highest degree it is also attached a source node.
-    The intra AS links are set with internal delay while inter AS source-router
-    links are set with external delay.
+    The intra AS links are set with internal delay while ABR to ABR
+    links are set with external delay. There are 2 ABRs between each two ASes.
     Parameters
     ----------
     asns : int list
@@ -790,83 +789,119 @@ def topology_multi_as(asns, source_ratio=0.1, ext_delay=EXTERNAL_LINK_DELAY, **k
     """
     if source_ratio < 0 or source_ratio > 1:
         raise ValueError('source_ratio must be comprised between 0 and 1')
+    # read rocketfuel files, depending on asns set by config.py
     f_t = [ path.join(TOPOLOGY_RESOURCES_DIR, 'rocketfuel-latency', str(i), 'latencies.intra') for i in asns]
     topologytmp = [fnss.parse_rocketfuel_isp_latency(i).to_undirected() for i in f_t]
+    # topology list of files
     topologylist = [list(nx.connected_component_subgraphs(i))[0] for i in topologytmp]
-    # First mark all current links as inernal
+    # relabel topology nodes with mapping function defined below, to differentiate nodes from different files
     for topology in topologylist:
         j = topologylist.index(topology)
         while j>=1:
             topology=nx.relabel_nodes(topology,mapping, copy=False)
             j -= 1
+    # First mark all current links as inernal
     for topology in topologylist:
         for u, v in topology.edges_iter():
             topology.edge[u][v]['type'] = 'internal'
-	
-	# Note: I don't need to filter out nodes with degree 1 cause they all have
-    # a greater degree value but we compute degree to decide where to attach sources
-    
+    # router nodes
     routerslist = [topology.nodes() for topology in topologylist]
-    # Source attachment
-    n_sourceslist = [int(source_ratio * len(routers)) for routers in routerslist]
-    sourceslist = [None] * len(n_sourceslist) 
+    n_sourceslist = [int(source_ratio * len(routers)) for routers in routerslist]#[3] * len(asns) #number of source nodes each AS, can be change to any
+    sourceslist = [None] * len(asns) #source nodes list
+    j=0
     for n_sources in n_sourceslist:
-        j = n_sourceslist.index(n_sources)
-        sourceslist[j] =['src_%d_%d' % (j,i) for i in range(n_sources)]    
-    
+        # src_ASj_i means the i_th source node in AS_j
+        sourceslist[j] =['src_AS%d_%d' % (j,i) for i in range(n_sources)]    
+        j += 1
+    # node degree
     deg = [nx.degree(topology) for topology in topologylist]
-
     # Attach sources based on their degree purely, but they may end up quite clustered
-    routerslistsort = [ sorted(routers, key=lambda k: deg[routerslist.index(routers)][k], reverse=True) for routers in routerslist ]
+    for routers in routerslist:
+        j=routerslist.index(routers)
+        # sort routers by degree within each AS
+        routers = sorted(routers, key=lambda k: deg[j][k], reverse=True) 
+    # add source to router links
     for sources in sourceslist:
         j = sourceslist.index(sources)
         for i in range(len(sources)):
-            #intra AS link set as internal, source to router delay bigger than router to receiver
-            topologylist[j].add_edge(sources[i], routerslistsort[j][i], delay=1, type='internal')
+            ##intra AS link set as internal, source to router delay bigger than router to receiver
+            topologylist[j].add_edge(sources[i], routerslist[j][i], delay=1, type='internal')
             #inter AS link set as external, AS_i source connect to AS_i+1(cycle of list)  router
-            if j==(len(sourceslist)-1):
-                topologylist[j].add_edge(sources[i], routerslistsort[0][i], delay=ext_delay, type='external')
-            else:            
-                topologylist[j].add_edge(sources[i], routerslistsort[j+1][i], delay=ext_delay, type='external')
-  
+            if i<2: # set ABR, we think 2ABR is a normal case between ASes
+                if j==(len(sourceslist)-1):
+                    # we set ABR to ABR dely as 25% of mean tested inter AS delay.
+                    # we test average intra AS delay is 75
+                    # 25% is taken from paper:
+                    # http://ieeexplore.ieee.org/document/1378228/
+                    topologylist[j].add_edge(routerslist[j][i], routerslist[0][i], delay=25, type='external')
+                else:            
+                    topologylist[j].add_edge(routerslist[j][i], routerslist[j+1][i], delay=25, type='external')
+ 
 
     # attach artificial receiver nodes to ICR candidates
-    receiverslist = [None]*len(routerslistsort)
-    for routers in routerslistsort:
-        j = routerslistsort.index(routers)
-        receiverslist[j] = ['rec_%d_%d' % (j,i) for i in range(len(routers))]
+    receiverslist = [None]*len(routerslist)
+    for routers in routerslist:
+        j = routerslist.index(routers)
+        receiverslist[j] = ['rec_AS%d_%d' % (j,i) for i in range(len(routers))]
         for i in range(len(routers)):
             topologylist[j].add_edge(receiverslist[j][i], routers[i], delay=0, type='internal')
     # Set weights to latency values
     for topology in topologylist:
         for u, v in topology.edges_iter():
             topology.edge[u][v]['weight'] = topology.edge[u][v]['delay']
+    # for print average degree of each AS
+    #for d in deg:
+        #suma=0
+        #for k,v in d.iteritems():
+            #suma+=v
+        #print ("average degree is %f" % (suma/len(d)))
 
     #multiple AS topology
     #we combine and import all the node,edge and attributes after individual definition of each AS
     #to provide scalability that being easier to change any one of them
-    topo_multiAS = nx.Graph()
-    for topology in topologylist:
-        j = topologylist.index(topology)    
+    routerall = set()
+    for routers in routerslist:
+        routerall=routerall.union(routers)
+    sourceall = set()
+    for sources in sourceslist:
+        sourceall=sourceall.union(sources)
+    receiverall = set()
+    for receivers in receiverslist:
+        receiverall=receiverall.union(receivers)
+
+    topo_multiAS = topologylist[0]
+    #combine nodes and edges into multi AS topo
+    for topology in topologylist[1:]:
         for v in topology.nodes():
             topo_multiAS.add_node(v)
         topo_multiAS.add_edges_from(topology.edges())
+
+    #set attribute
+    topo_multiAS.graph['icr_candidates']=set(routerall) 
+    for topology in topologylist:    
+        j = topologylist.index(topology)    
         delays = nx.get_edge_attributes(topology, 'delay')
         types = nx.get_edge_attributes(topology, 'type')
         weights = nx.get_edge_attributes(topology, 'weight')
         nx.set_edge_attributes(topo_multiAS,'delay',delays)
         nx.set_edge_attributes(topo_multiAS,'type',types)
         nx.set_edge_attributes(topo_multiAS,'weight',weights)
-        
-        # Deploy stacks on nodes
-        topo_multiAS.graph['icr_candidates'] = set(routerslistsort[j])
-        for v in sourceslist[j]:
-            fnss.add_stack(topo_multiAS, v, 'source')
-        for v in receiverslist[j]:
-            fnss.add_stack(topo_multiAS, v, 'receiver')
-        for v in routerslistsort[j]:
-            fnss.add_stack(topo_multiAS, v, 'router')
-        
+
+    # Deploy stacks on nodes
+    for v in sourceall:
+        fnss.add_stack(topo_multiAS, v, 'source')
+    for v in receiverall:
+        fnss.add_stack(topo_multiAS, v, 'receiver')
+    for v in routerall:
+        fnss.add_stack(topo_multiAS, v, 'router')
+    for u, v in topo_multiAS.edges():
+        if u in sources or v in sources:
+            topo_multiAS.edge[u][v]['type'] = 'external'
+            # this prevents sources to be used to route traffic
+            fnss.set_weights_constant(topo_multiAS, 1000.0, [(u, v)])
+            fnss.set_delays_constant(topo_multiAS, EXTERNAL_LINK_DELAY, 'ms', [(u, v)])
+        else:
+            topo_multiAS.edge[u][v]['type'] = 'internal'
     return IcnTopology(topo_multiAS)
 
 def mapping(x):


### PR DESCRIPTION
Parsed multiple rocketfuel topology files.
Taking each as an AS.
source-router link across ASes are set with external delay.